### PR TITLE
Remove --no-trunc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Report image details
         run: >
           docker image history
-          --no-trunc
           --format "table {{.Size}}\t{{.CreatedBy}}"
           ${{steps.info.outputs.package}}
       - name: Run tests


### PR DESCRIPTION
Extra info isn't very helpful and it makes it harder to read.